### PR TITLE
Add CI to run Gradle tests on PR open

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -1,0 +1,19 @@
+name: Gradle Tests
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: current
+      - run: gradle test


### PR DESCRIPTION
## Summary
- run unit tests using Gradle when a pull request is opened

## Testing
- `gradle test --no-daemon`